### PR TITLE
Fixed failure on quit in repl

### DIFF
--- a/jpizza/src/main/java/lemon/jpizza/Shell.java
+++ b/jpizza/src/main/java/lemon/jpizza/Shell.java
@@ -143,7 +143,7 @@ public class Shell {
         else if (Objects.equals(target, "docs")) {
             Shell.logger.outln("Documentation can be found at https://jpizza.readthedocs.io/en/latest/");
         }
-        else if (target == null) {
+        else if (target == null && !(flags == Flags.SHELL)) {
             Shell.logger.fail("No target specified");
         }
         else {
@@ -225,6 +225,7 @@ public class Shell {
             }
         }
         in.close();
+        System.exit(0);
     }
 
     public static Pair<List<Node>, Error> getAst(String fn, String text) {


### PR DESCRIPTION
Apon starting the repl, you previously would get this
```
Exit with 'quit'
-> quit
                FAILURE
────────────────────────────────────────
No target specified
```
Now, it exits apon quit being used, with no failure and with exit code 0.